### PR TITLE
Add OnPageSelect event

### DIFF
--- a/dist/Data/Source/Scripts/MCM_ConfigBase.psc
+++ b/dist/Data/Source/Scripts/MCM_ConfigBase.psc
@@ -9,7 +9,7 @@ Event OnSettingChange(string a_ID)
 EndEvent
 
 ; Event raised when a new page is selected, including the initial empty page.
-Event OnPageChange(string a_page)
+Event OnPageSelect(string a_page)
 EndEvent
 
 ; Event raised when a config menu is first initialized.

--- a/dist/Data/Source/Scripts/MCM_ConfigBase.psc
+++ b/dist/Data/Source/Scripts/MCM_ConfigBase.psc
@@ -8,6 +8,10 @@ Scriptname MCM_ConfigBase extends SKI_ConfigBase
 Event OnSettingChange(string a_ID)
 EndEvent
 
+; Event raised when a new page is selected, including the initial empty page.
+Event OnPageChange(string a_page)
+EndEvent
+
 ; Event raised when a config menu is first initialized.
 Event OnConfigInit()
 EndEvent

--- a/dist/Detail/Source/Scripts/MCM_ConfigBase.psc
+++ b/dist/Detail/Source/Scripts/MCM_ConfigBase.psc
@@ -8,6 +8,10 @@ Scriptname MCM_ConfigBase extends SKI_ConfigBase
 Event OnSettingChange(string a_ID)
 EndEvent
 
+; Event raised when a new page is selected, including the initial empty page.
+Event OnPageChange(string a_page)
+EndEvent
+
 ;-----------------
 ; MCM
 ;-----------------

--- a/dist/Detail/Source/Scripts/MCM_ConfigBase.psc
+++ b/dist/Detail/Source/Scripts/MCM_ConfigBase.psc
@@ -9,7 +9,7 @@ Event OnSettingChange(string a_ID)
 EndEvent
 
 ; Event raised when a new page is selected, including the initial empty page.
-Event OnPageChange(string a_page)
+Event OnPageSelect(string a_page)
 EndEvent
 
 ;-----------------

--- a/include/Papyrus/MCM_ConfigBase.h
+++ b/include/Papyrus/MCM_ConfigBase.h
@@ -58,7 +58,11 @@ namespace Papyrus
 			std::string_view a_value);
 
 		// SkyUI Overrides
-		static void OnPageReset(RE::TESQuest* a_self, std::string a_page);
+		static void OnPageReset(
+			RE::BSScript::IVirtualMachine* a_vm,
+			RE::VMStackID a_stackID,
+			RE::TESQuest* a_self,
+			std::string a_page);
 
 		static void OnOptionHighlight(RE::TESQuest* a_self, std::int32_t a_option);
 
@@ -126,6 +130,11 @@ namespace Papyrus
 			RE::BSScript::IVirtualMachine* a_vm,
 			ScriptObjectPtr a_object,
 			std::string a_ID);
+
+		static void SendPageChangeEvent(
+			RE::BSScript::IVirtualMachine* a_vm,
+			ScriptObjectPtr a_object,
+			std::string a_page);
 
 		// Registration delegate
 		static bool RegisterFuncs(RE::BSScript::IVirtualMachine* a_vm);

--- a/include/Papyrus/MCM_ConfigBase.h
+++ b/include/Papyrus/MCM_ConfigBase.h
@@ -131,7 +131,7 @@ namespace Papyrus
 			ScriptObjectPtr a_object,
 			std::string a_ID);
 
-		static void SendPageChangeEvent(
+		static void SendPageSelectEvent(
 			RE::BSScript::IVirtualMachine* a_vm,
 			ScriptObjectPtr a_object,
 			std::string a_page);

--- a/src/Papyrus/MCM_ConfigBase.cpp
+++ b/src/Papyrus/MCM_ConfigBase.cpp
@@ -115,7 +115,7 @@ namespace Papyrus
 		if (config) {
 			config->ShowPage(object, a_page);
 
-			SendPageChangeEvent(a_vm, object, a_page);
+			SendPageSelectEvent(a_vm, object, a_page);
 		}
 	}
 
@@ -571,7 +571,7 @@ namespace Papyrus
 		UpdateInfoText(a_object, true);
 	}
 
-	void MCM_ConfigBase::SendPageChangeEvent(
+	void MCM_ConfigBase::SendPageSelectEvent(
 		RE::BSScript::IVirtualMachine* a_vm,
 		ScriptObjectPtr a_object,
 		std::string a_page)
@@ -580,7 +580,7 @@ namespace Papyrus
 
 		ScriptCallbackPtr nullCallback;
 		auto args = RE::MakeFunctionArguments(std::move(a_page));
-		a_vm->DispatchMethodCall(a_object, "OnPageChange"sv, args, nullCallback);
+		a_vm->DispatchMethodCall(a_object, "OnPageSelect"sv, args, nullCallback);
 		delete args;
 	}
 

--- a/src/Papyrus/MCM_ConfigBase.cpp
+++ b/src/Papyrus/MCM_ConfigBase.cpp
@@ -103,13 +103,19 @@ namespace Papyrus
 		SettingStore::GetInstance().SetModSettingString(modName, a_settingName, a_value);
 	}
 
-	void MCM_ConfigBase::OnPageReset(RE::TESQuest* a_self, std::string a_page)
+	void MCM_ConfigBase::OnPageReset(
+		RE::BSScript::IVirtualMachine* a_vm,
+		[[maybe_unused]] RE::VMStackID a_stackID,
+		RE::TESQuest* a_self,
+		std::string a_page)
 	{
 		auto object = ScriptObject::FromForm(a_self, ScriptName);
 		auto config = ConfigStore::GetInstance().GetConfig(a_self);
 
 		if (config) {
 			config->ShowPage(object, a_page);
+
+			SendPageChangeEvent(a_vm, object, a_page);
 		}
 	}
 
@@ -563,6 +569,19 @@ namespace Papyrus
 		delete args;
 
 		UpdateInfoText(a_object, true);
+	}
+
+	void MCM_ConfigBase::SendPageChangeEvent(
+		RE::BSScript::IVirtualMachine* a_vm,
+		ScriptObjectPtr a_object,
+		std::string a_page)
+	{
+		assert(a_vm);
+
+		ScriptCallbackPtr nullCallback;
+		auto args = RE::MakeFunctionArguments(std::move(a_page));
+		a_vm->DispatchMethodCall(a_object, "OnPageChange"sv, args, nullCallback);
+		delete args;
 	}
 
 	bool MCM_ConfigBase::RegisterFuncs(RE::BSScript::IVirtualMachine* a_vm)


### PR DESCRIPTION
I found it odd how SkyUI's OnPageReset event wasn't available, but having looked at how it is intermingled with MCM Helper, it would require config authors to call the parent as well to ensure the menu doesn't break. I decided to add a replacement. This also allows me to use SetMenuOptions.