### PR TITLE
Defend against a crash in dynamically-created menus

### DIFF
--- a/src/Config/Control.cpp
+++ b/src/Config/Control.cpp
@@ -345,9 +345,9 @@ std::string MenuControl::GetShortText() const
 
 	const auto value = GetValue();
 	const auto item = std::ranges::find(options, value);
-	const auto index = std::distance(options.begin(), item);
+	const size_t index = std::distance(options.begin(), item);
 
-	return shortNames[index];
+	return index < shortNames.size() ? shortNames[index] : ""s;
 }
 
 std::int32_t EnumControl::Add(const ScriptObjectPtr& a_configScript)


### PR DESCRIPTION
This bug showed up as a crash in `MenuControl::GetShortText()` in my mod.

If both the values and the short names arrays are empty, `GetValue()` returns empty string, which `std::ranges::find()` does not find in the empty short names array. The distance from array end to beginning is therefore 0, and the subsequent index into `shortNames` causes a crash.

Detect this case and return empty string.

I tripped over this because I have some dynamic menus that are sometimes empty. I've worked around the problem in my mod, but I thought you might want the fix.